### PR TITLE
two different deployments depending on branch: master or release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ before_install:
   -in cfg/codesigning.asc.enc -out cfg/codesigning.asc -d
 - gpg --fast-import cfg/codesigning.asc
 deploy:
-  provider: script
-  script: mvn clean deploy --settings cfg/settings.xml -P signing -DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/service/local/staging/deploy/maven2
-  on:
-    branch: release
-
+  - provider: script
+    script: mvn clean deploy --settings cfg/settings.xml -P signing -DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/service/local/staging/deploy/maven2
+    on:
+      branch: release
+  - provider: script
+    script: mvn clean deploy --settings cfg/settings.xml -P signing -DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/content/repositories/snapshots
+    on:
+      branch: master
 
 env:
   global:


### PR DESCRIPTION
For the 'master' branch we perform snapshot releases.
For the 'release' branch we perform releases into the sonatype/mavencentral stage.

For all other braches, e.g. feature branches there is no deployment.

There is no check for '-SNAPSHOT', neither that they are present on
the master branch for snapshot release, nor that they are not present
on the release branch for the staging repo.