### PR TITLE
WIP: Moving the CM Client's Docker file out of devops-docker-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM openjdk:8-jre-slim
+
+ARG version=2.0.1
+
+ENV CMCLIENT_HOME /opt/sap/cmclient
+
+RUN PROTOCOL='http' && \
+    REPO_URL='repo1.maven.org/maven2' && \
+    G='com.sap.devops.cmclient' && \
+    A='dist.cli' && \
+    V=${version} && \
+    P='tar.gz' && \
+    apt-get update && apt-get install -y \
+      curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p "${CMCLIENT_HOME}" && \
+    curl --silent --show-error  "${PROTOCOL}://${REPO_URL}/`echo ${G}|sed 's|\.|/|g'`/${A}/${V}/${A}-${V}.${P}" \
+    |tar -C "${CMCLIENT_HOME}" -xvzf - && \
+    curl --silent --show-error --output ${CMCLIENT_HOME}/LICENSE https://raw.githubusercontent.com/SAP/devops-cm-client/master/LICENSE && \
+    chown -R root:root "${CMCLIENT_HOME}" && \
+    ln -s "${CMCLIENT_HOME}/bin/cmclient" "/usr/local/bin/cmclient" && \
+    apt-get remove --purge --autoremove -y \
+      curl && \
+    INSTALLED_VERSION=`cmclient --version |sed -e 's/ :.*//g'` && \
+    echo "[INFO] cm client version: ${INSTALLED_VERSION}" && \
+    [ "${version}" = "${INSTALLED_VERSION}" ] || { echo "[ERROR] Installed version of cm client ('${INSTALLED_VERSION}') does not match expected version ('${version}')." && exit 1; }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,19 @@ the actions necessary within those scenarios. See section _Usage_ for more detai
 
 This command line client can be consumed either as a Java application from [maven.org](http://repo1.maven.org/maven2/com/sap/devops/cmclient/dist.cli) or as a Docker image from [hub.docker.com](https://hub.docker.com/r/ppiper/cm-client).
 
-## Installation from maven.org
+
+## Using the Docker Image
+On a linux machine you can run 
+
+`docker run --rm ppiper/cm-client cmclient --help`
+
+This will print the CM Client's help information. For a comprehensive overview of available commands please read the [usage information](#usage) below.
+
+### How to Build the Docker Image
+
+`docker build -t cm-client .`
+
+## Using the Java Application from maven.org
 
   - Download the command line interface package from [maven.org](http://repo1.maven.org/maven2/com/sap/devops/cmclient/dist.cli)
   - Extract the command line interface package into suitable folder
@@ -107,4 +119,3 @@ otherwise in the [LICENSE file][license].
 
 # Release Notes
 The release notes are available [here](RELEASES.md).
-


### PR DESCRIPTION
Just moving the Docker file and readme contents from the devops-docker-images repo to "where it really belongs". I chose the master branch, because the Dockerfile doesn't interfere with any existing content. Additionally I merged the readme description to accomodate the docker usage.

What's missing: once we merge this we should set up the build on Dockerhub.